### PR TITLE
chore(az): update az cli to 2.0.46

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 LABEL name="deis-go-dev"
 
-ENV AZCLI_VERSION=2.0.45 \
+ENV AZCLI_VERSION=2.0.46 \
     GO_VERSION=1.11 \
     GLIDE_VERSION=v0.13.1 \
     GLIDE_HOME=/root \


### PR DESCRIPTION
Includes support pushing helm packages with path reference